### PR TITLE
Um exemplo mostrando que é mais interessante usar o linkdHashSet na c…

### DIFF
--- a/src/generics/ComparableTeste.java
+++ b/src/generics/ComparableTeste.java
@@ -1,0 +1,24 @@
+package generics;
+
+import java.util.TreeSet;
+
+public class ComparableTeste {
+
+    public static void main(String[] args) {
+
+        TreeSet<Integer> nums = new TreeSet<>();
+
+        nums.add(10);
+        nums.add(1);
+        nums.add(3);
+        nums.add(6);
+        nums.add(8);
+        nums.add(9);
+        nums.add(123);
+        nums.add(-13);
+
+        for (Integer n : nums) {
+            System.out.println(n);
+        }
+    }
+}


### PR DESCRIPTION
…lasse Pares, pois ela não usa comparable como o TreeSet que dificultaria definir comparações para tipos genéricos